### PR TITLE
Fix build error on Linux - 'bool' undefined

### DIFF
--- a/kext/khmm_wrap.c
+++ b/kext/khmm_wrap.c
@@ -1447,9 +1447,6 @@ SWIG_Perl_SetModule(swig_module_info *module) {
 #ifdef eof
   #undef eof
 #endif
-#ifdef bool
-  #undef bool
-#endif
 #ifdef close
   #undef close
 #endif


### PR DESCRIPTION
Building with a Fedora22 distribution, on x86-64 gives many errors:

gcc `perl -MExtUtils::Embed -e ccopts` -fPIC   -c -o khmm_wrap.o khmm_wrap.c
In file included from khmm_wrap.c:730:0:
khmm_wrap.c: In function ‘SWIG_AsCharPtrAndSize’:
/usr/lib64/perl5/CORE/handy.h:124:34: error: ‘bool’ undeclared (first use in this function)
 #define cBOOL(cbool) ((cbool) ? (bool)1 : (bool)0)
                                  ^
/usr/lib64/perl5/CORE/perl.h:3158:62: note: in definition of macro ‘EXPECT’
 #  define EXPECT(expr,val)                  __builtin_expect(expr,val)
                                                              ^
/usr/lib64/perl5/CORE/perl.h:3162:52: note: in expansion of macro ‘cBOOL’
 #define LIKELY(cond)                        EXPECT(cBOOL(cond),TRUE)

...

Removing the '#undef bool' from khmm_wrap.c fixes these, and allows a successful build.

Signed-off-by: Mark Einon <mark.einon@gmail.com>